### PR TITLE
CMake changes to run on mac (+other platforms too)

### DIFF
--- a/placer/CMakeLists.txt
+++ b/placer/CMakeLists.txt
@@ -1,9 +1,18 @@
 cmake_minimum_required(VERSION 3.5)
 project(629_placer)
 
-set(CMAKE_BUILD_TYPE Release)
+# find umfpack
+find_path(UMFPACK_INCLUDE_DIR umfpack.h PATH_SUFFIXES suitesparse REQUIRED)
+find_library(UMFPACK_LIB umfpack REQUIRED)
+include_directories(${UMFPACK_INCLUDE_DIR})
+
+# find x11
+find_package(X11 REQUIRED)
+include_directories(${X11_INCLUDE_DIR})
+
 # set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 add_subdirectory(easygl)

--- a/placer/easygl/CMakeLists.txt
+++ b/placer/easygl/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_library(easygl SHARED graphics.cpp)
-target_link_libraries(easygl X11)
+target_link_libraries(easygl ${X11_LIBRARIES})

--- a/placer/src/CMakeLists.txt
+++ b/placer/src/CMakeLists.txt
@@ -7,5 +7,5 @@ add_executable(placer
 	Net.cpp
 )
 
-target_link_libraries(placer easygl X11 umfpack)
+target_link_libraries(placer easygl ${UMFPACK_LIB})
 

--- a/placer/src/Design.cpp
+++ b/placer/src/Design.cpp
@@ -17,7 +17,7 @@
 #include "Net.h"
 #include "easygl/graphics.h"
 
-#include <suitesparse/umfpack.h>
+#include <umfpack.h>
 
 using namespace std;
 

--- a/router/CMakeLists.txt
+++ b/router/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(629_router)
 
+# find x11
+find_package(X11 REQUIRED)
+include_directories(${X11_INCLUDE_DIR})
+
 # set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 17)

--- a/router/easygl/CMakeLists.txt
+++ b/router/easygl/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_library(easygl SHARED graphics.cpp)
-target_link_libraries(easygl X11)
+target_link_libraries(easygl ${X11_LIBRARIES})


### PR DESCRIPTION
- used find_package to include X11
- used find_path/library to find umfpack.
(Works if umfpack is or is not installed as part of suitesparse)

The only confusing thing is that now umfpack is included as <umfpack.h>. This works on both Mac and ubuntu if you have cmake setup correctly, but stops working of you get rid of the special cmake configuration.